### PR TITLE
Add ACE LDFA model generation for arbitrary order of atoms in structure.

### DIFF
--- a/src/ace_ldfa.jl
+++ b/src/ace_ldfa.jl
@@ -16,8 +16,10 @@ end
 
 
 function density!(model::AceLDFA, rho::AbstractVector, R::AbstractMatrix, friction_atoms::AbstractVector)
+    # Needs a structure with only one "friction_atom" atom type for evaluation. 
+    one_frictionatom_indices = length(friction_atoms)≥2 ? symdiff(1:size(R,2), friction_atoms[2:end]) : 1:size(R,2)
     for i in friction_atoms
-        xR = R[:,1:end-length(friction_atoms)+1] # we assume that friction atoms are at the end
+        xR = R[:,one_frictionatom_indices] 
         xR[:,end]=R[:,i]
         rho[i] = austrip(au_to_eV(NQCModels.potential(model.ml_model, xR)) * model.density_unit)
     end


### PR DESCRIPTION
This should make ACE LDFA work immediately with arbitrary structures by removing all but one atom specified in `friction_atoms`, so no specific structural order is needed. 