### PR TITLE
🐛 ACELDFA constructure StackOverflows

### DIFF
--- a/src/ace_ldfa.jl
+++ b/src/ace_ldfa.jl
@@ -23,10 +23,6 @@ ACE.jl electron density friction provider.
     The unit in which the ACE model predicts the electron density. By default, this is in Å^-3 and should be converted to atomic units of Bohr^-3. 
 
 """
-function AceLDFA(friction_IP; density_unit=u"Å^-3")
-    AceLDFA(friction_IP, density_unit)
-end
-
 
 function NQCModels.FrictionModels.density!(model::AceLDFA, rho::AbstractVector, R::AbstractMatrix, friction_atoms::AbstractVector{Int})
     # Needs a structure with only one "friction_atom" atom type for evaluation. 


### PR DESCRIPTION
This stackoverflow was my fault - `AceLDFA` expects two arguments, and I wanted to specify a nonstandard constructor which also took two arguments. Since both the struct and method definition weren't type specific, a stackoverflow happened. 